### PR TITLE
Four possible changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.acn
 *.acr
 *.alg
-*.aux
+# Don't ignore .aux -- these are checked-in files in test/
+#*.aux
 *.bbl
 *.blg
 *.dvi

--- a/model2-names-astronomy.bst
+++ b/model2-names-astronomy.bst
@@ -367,7 +367,7 @@ MACRO {pasa} {"Publ. Astron. Soc. Aust."}
 MACRO {pasp} {"Publ. Astron. Soc. Pac."}
 MACRO {pasj} {"Publ. Astron. Soc. Jpn."}
 MACRO {rmxaa} {"Rev. Mex. Astron. Astr."}
-MACRO {rjras} {"Q. J. Roy. Astron. Soc."}
+MACRO {qjras} {"Q. J. Roy. Astron. Soc."}
 MACRO {skytel} {"Sky Telescope"}
 MACRO {solphys} {"Sol. Phys."}
 MACRO {sovast} {"Sov. Astron."}

--- a/model2-names-astronomy.bst
+++ b/model2-names-astronomy.bst
@@ -62,7 +62,6 @@ FUNCTION {init.web.variables}
 {
   "\URLprefix "     'urlprefix :=
   "\DOIprefix"      'doiprefix :=
-  "\ArXivprefix  "   'eprintprefix :=
   "\Pubmedprefix "  'pubmedprefix :=
   #8 'maxauthors :=
 }
@@ -935,39 +934,65 @@ FUNCTION {format.organization.address}
 }
 
 FUNCTION {print.url}
- {url duplicate$ empty$
-   { pop$ "" }
-   { new.sentence
-     urlprefix "\url{" * swap$  * "}" *
-   }
-   if$
- }
+{ url duplicate$ empty$
+    { pop$ "" }
+    { new.sentence
+      urlprefix "\url{" * swap$  * "}" *
+    }
+  if$
+}
 
 FUNCTION {print.doi}
- {doi duplicate$ empty$
-   { pop$ "" }
-   { new.sentence
-     doiprefix "\doi{" * swap$  * "}" *
-   }
-   if$
- }
+{ doi duplicate$ empty$
+    { pop$ "" }
+    { new.sentence
+      doiprefix "\doi{" * swap$  * "}" *
+    }
+  if$
+}
 
+% The format of the output string is specifically {\tt arXiv:nnn}, and
+% not for example \texttt{arXiv:nnn} (see http://arxiv.org/help/faq/references).
+% The format of the ascl reference isn't specified so precisely, but
+% we should use the same format.
 FUNCTION {print.eprint}
- {eprint duplicate$ empty$
-   { pop$ "" }
-   { new.sentence
-     duplicate$ "\href{http://arxiv.org/abs/" swap$ * "}{{\tt arXiv:" * swap$ * "}}" *   }
-   if$
- }
+{ eprint empty$
+    { "" }
+    { new.sentence
+      % Match arxiv:nnn or arXiv:nnn
+      eprint #1 #6 substring$
+      duplicate$ "arXiv:" = swap$ "arxiv:" = or
+        { eprint #7 #999 substring$ duplicate$
+          "\href{http://arxiv.org/abs/" swap$ * "}{{\tt arXiv:" * swap$ * "}}" *
+        }
+        { % match ascl:
+          eprint #1 #5 substring$
+          "ascl:" =
+            { eprint #6 #999 substring$ duplicate$
+              "\href{http://ascl.net/" swap$ * "}{{\tt ascl:" * swap$ * "}}" *
+            }
+            { % no recognised prefix: default to arXiv
+              eprint duplicate$
+              "\href{http://arxiv.org/abs/" swap$ * "}{{\tt arXiv:" * swap$ * "}}" *
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
 
+% XXX Should 'pubmed:' be incorporated into the above 'print.eprint'
+% scheme?  This would mean that one could write eprint='pubmed:xxx'
+% and have that recognised and formatted as a pubmed text.
 FUNCTION {print.pubmed}
- {pubmed duplicate$ empty$
+{ pubmed duplicate$ empty$
    { pop$ "" }
    { new.sentence
      pubmedprefix "\Pubmed{" * swap$  * "}" *
    }
    if$
- }
+}
 
 FUNCTION {webpage}
 { "%Type = Webpage" write$
@@ -1630,8 +1655,6 @@ FUNCTION {begin.bib}
   "\providecommand{\path}[1]{#1}"
   write$ newline$
   "\providecommand{\DOIprefix}{doi:}"
-  write$ newline$
-  "\providecommand{\ArXivprefix}{arXiv:}"
   write$ newline$
   "\providecommand{\URLprefix}{URL: }"
   write$ newline$

--- a/model2-names-example.tex
+++ b/model2-names-example.tex
@@ -1,13 +1,13 @@
-% mn2e-example.tex
+% model2-names-example.tex
 %
-% This is a skeleton MN-format article which displays the generated
-% test bibliography (mn2e-test.bbl) as it would appear in an article.
+% This is a skeleton elsarticle-format article which displays the generated
+% test bibliography as it would appear in an article.
 % To see this, try:
 %
-%     make mn2e-example.pdf
+%     pdflatex model2-names-example
 %
-% Note that the mn2e-test.aux file is written by hand; the
-% mn2e-example.aux file generated from this file is ignored.
+% Note that the tests/test-maxauthors.aux file is written by hand; the
+% model2-names-example.aux file generated from this file is ignored.
 
 \documentclass[authoryear,10pt,5p,times]{elsarticle}
 
@@ -31,20 +31,6 @@ It is important to make reference to things.
 
 \end{frontmatter}
 
-% The following implements the three-author-hack described in
-% mn2e.bst.  This should be moved to mn2e.cls at some point.
-%
-% This consumes a command for each such author.  It's surely possible
-% to avoid this (with some constructions involving {\\#1}; see
-% Appendix D cleverness), but that would verge on the arcane, and not
-% be really worth it.
-%% \makeatletter
-%% \def\mniiiauthor#1#2#3{%
-%%   \@ifundefined{mniiiauth@#1}
-%%     {\global\expandafter\let\csname mniiiauth@#1\endcsname\null #2}
-%%     {#3}}
-%% \makeatother
-
 \section{Introduction}
 
 There are numerous citations here.
@@ -52,52 +38,52 @@ There are numerous citations here.
 In particular, there is
 `one'~\citep{one},
 `oneplus'~\citep{oneplus},
-`onereprised'~\citep{onereprised},
-`two'~\citep{two},
-`twoplus'~\citep{twoplus},
-`twobis'~\citep{twobis},
-`twobook'~\citep{twobook},
-`twomisc~\citep{twomisc},
-`tworeprised'~\citep{tworeprised},
+%`onereprised'~\citep{onereprised},
+%`two'~\citep{two},
+%`twoplus'~\citep{twoplus},
+%`twobis'~\citep{twobis},
+%`twobook'~\citep{twobook},
+%`twomisc~\citep{twomisc},
+%`tworeprised'~\citep{tworeprised},
 `three'~\citep{three},
-`threeplus'~\citep{threeplus},
-`threereprised'~\citep{threereprised},
-`four'~\citep{four},
-`fourplus'~\citep{fourplus},
-`seven'~\citep{seven},
-`sevenplus'~\citep{sevenplus},
+%`threeplus'~\citep{threeplus},
+%`threereprised'~\citep{threereprised},
+%`four'~\citep{four},
+%`fourplus'~\citep{fourplus},
+%`seven'~\citep{seven},
+%`sevenplus'~\citep{sevenplus},
 `eight'~\citep{eight},
-`eightplus'~\citep{eightplus},
+%`eightplus'~\citep{eightplus},
 `nine'~\citep{nine},
-`nineplus'~\citep{nineplus},
-`ten'~\citep{ten},
-`tenplus'~\citep{tenplus} and
-`tenbis'~\citep{tenbis}.
+%`nineplus'~\citep{nineplus},
+%`ten'~\citep{ten},
+%`tenplus'~\citep{tenplus} and
+%`tenbis'~\citep{tenbis}.
 
-And secondly, there is
-`one'~\citep{one},
-`oneplus'~\citep{oneplus},
-`onereprised'~\citep{onereprised},
-`two'~\citep{two},
-`twoplus'~\citep{twoplus},
-`twobis'~\citep{twobis},
-`twobook'~\citep{twobook},
-`twomisc~\citep{twomisc},
-`tworeprised'~\citep{tworeprised},
-`three'~\citep{three},
-`threeplus'~\citep{threeplus},
-`threereprised'~\citep{threereprised},
-`four'~\citep{four},
-`fourplus'~\citep{fourplus},
-`seven'~\citep{seven},
-`sevenplus'~\citep{sevenplus},
-`eight'~\citep{eight},
-`eightplus'~\citep{eightplus},
-`nine'~\citep{nine},
-`nineplus'~\citep{nineplus},
-`ten'~\citep{ten},
-`tenplus'~\citep{tenplus} and
-`tenbis'~\citep{tenbis}.
+%% And secondly, there is
+%% `one'~\citep{one},
+%% `oneplus'~\citep{oneplus},
+%% `onereprised'~\citep{onereprised},
+%% `two'~\citep{two},
+%% `twoplus'~\citep{twoplus},
+%% `twobis'~\citep{twobis},
+%% `twobook'~\citep{twobook},
+%% `twomisc~\citep{twomisc},
+%% `tworeprised'~\citep{tworeprised},
+%% `three'~\citep{three},
+%% `threeplus'~\citep{threeplus},
+%% `threereprised'~\citep{threereprised},
+%% `four'~\citep{four},
+%% `fourplus'~\citep{fourplus},
+%% `seven'~\citep{seven},
+%% `sevenplus'~\citep{sevenplus},
+%% `eight'~\citep{eight},
+%% `eightplus'~\citep{eightplus},
+%% `nine'~\citep{nine},
+%% `nineplus'~\citep{nineplus},
+%% `ten'~\citep{ten},
+%% `tenplus'~\citep{tenplus} and
+%% `tenbis'~\citep{tenbis}.
 
 
 
@@ -105,7 +91,7 @@ And secondly, there is
 % debugging.  That's generally commented out, but if you need to
 % uncomment that, then uncomment this, too.
 %\def\logsortkey#1{{[\tiny #1]}}
-%\input{model2-names-test.bbl}
+\input{tests/test-maxauthors.bbl}
 
 \bibliographystyle{model2-names-astronomy}
 \bibliography{model2-names-test}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-CHECKS=test-inproceedings test-eprints
+CHECKS=test-inproceedings test-eprints test-maxauthors
 
 %.bbl: %.aux model2-names-test.bib ../model2-names-astronomy.bst
 	bibtex $<

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,11 @@
-CHECKS=test-inproceedings
+CHECKS=test-inproceedings test-eprints
 
 %.bbl: %.aux model2-names-test.bib ../model2-names-astronomy.bst
 	bibtex $<
 
 %.diff: %.bbl
 	rm -f $@
-	diff $< ${<}-correct >$@ || :
+	diff ${<}-correct $< >$@ || :
 
 # The following succeeds, and prints 'All tests OK', if all of the
 # .diff files are of zero size; if one or more is non-empty, it

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,28 @@
+CHECKS=test-inproceedings
+
+%.bbl: %.aux model2-names-test.bib ../model2-names-astronomy.bst
+	bibtex $<
+
+%.diff: %.bbl
+	rm -f $@
+	diff $< ${<}-correct >$@ || :
+
+# The following succeeds, and prints 'All tests OK', if all of the
+# .diff files are of zero size; if one or more is non-empty, it
+# reports that, and ends reporting an error.
+#
+# 'test -s filename' is true if 'filename' exists and has non-zero size
+check: $(CHECKS:=.diff)
+	@allgood=:; \
+	  for f in $(CHECKS); do \
+	    if test -s $$f.diff; then \
+	      echo "FAIL: $$f"; allgood=false; \
+	    else \
+	      echo "OK: $$f"; rm $$f.diff; \
+	    fi; \
+	  done; \
+	$$allgood
+	@echo "All tests OK"
+
+clean:
+	rm -f *.bbl *.blg *.diff

--- a/tests/model2-names-test.bib
+++ b/tests/model2-names-test.bib
@@ -247,3 +247,16 @@
   year = 	 2001
 }
 
+@InProceedings{proc1,
+  author =       {Albert One and Benedict Two},
+  title =        {Albie and Ben's Wonderful Adventure},
+  booktitle =    {Proceedings of the Incredibly Interesting Conference},
+  year =         2014,
+  editor =       {Zephenia Ten and Yannis Nine},
+  number =       99,
+  series =       {Fascinating and Fun Factbooks},
+  pages =        {123-124},
+  month =        jan,
+  publisher =    {Publishers Megacorp}
+}
+

--- a/tests/model2-names-test.bib
+++ b/tests/model2-names-test.bib
@@ -260,3 +260,25 @@
   publisher =    {Publishers Megacorp}
 }
 
+@Article{eprint1,
+  author =       {Albert One},
+  title =        {Article with Preprint},
+  journal =      prl,
+  year =         2014,
+  eprint =       {1401.0001}
+}
+@Article{eprint2,
+  author =       {Benedict Two},
+  title =        {Another Article with Preprint},
+  journal =      prl,
+  year =         2014,
+  eprint =       {arxiv:1401.0002}
+}
+@Article{eprint3,
+  author =       {Coriolanus Three},
+  title =        {Yet Another Article with Computing Preprint},
+  journal =      prl,
+  year =         2014,
+  eprint =       {ascl:1401.003}
+}
+

--- a/tests/test-eprints.aux
+++ b/tests/test-eprints.aux
@@ -1,0 +1,11 @@
+% How are 'eprint' entries formatted?
+% eprint1 is an arXiv reference without any prefix, eprint2 has an
+% explicit 'arxiv:' prefix, and eprint3 has 'ascl:'.
+\relax
+% citation 'one' has no eprint
+\citation{one}
+\citation{eprint1}
+\citation{eprint2}
+\citation{eprint3}
+\bibstyle{../model2-names-astronomy}
+\bibdata{model2-names-test}

--- a/tests/test-eprints.bbl-correct
+++ b/tests/test-eprints.bbl-correct
@@ -1,0 +1,38 @@
+\begin{thebibliography}{4}
+\expandafter\ifx\csname natexlab\endcsname\relax\def\natexlab#1{#1}\fi
+\providecommand{\url}[1]{\texttt{#1}}
+\providecommand{\href}[2]{#2}
+\providecommand{\path}[1]{#1}
+\providecommand{\DOIprefix}{doi:}
+\providecommand{\URLprefix}{URL: }
+\providecommand{\Pubmedprefix}{pmid:}
+\providecommand{\doi}[1]{\href{http://dx.doi.org/#1}{\path{#1}}}
+\providecommand{\Pubmed}[1]{\href{pmid:#1}{\path{#1}}}
+\providecommand{\bibinfo}[2]{#2}
+\ifx\xfnm\relax \def\xfnm[#1]{\unskip,\space#1}\fi
+%Type = Article
+\bibitem[{One(2001)}]{one}
+\bibinfo{author}{One, A.}, \bibinfo{year}{2001}.
+\newblock \bibinfo{title}{One alone}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{1},
+  \bibinfo{pages}{101--104}.
+%Type = Article
+\bibitem[{One(2014)}]{eprint1}
+\bibinfo{author}{One, A.}, \bibinfo{year}{2014}.
+\newblock \bibinfo{title}{Article with preprint}.
+\newblock \bibinfo{journal}{Phys. Rev. Lett}
+  \href{http://arxiv.org/abs/1401.0001}{{\tt arXiv:1401.0001}}.
+%Type = Article
+\bibitem[{Three(2014)}]{eprint3}
+\bibinfo{author}{Three, C.}, \bibinfo{year}{2014}.
+\newblock \bibinfo{title}{Yet another article with computing preprint}.
+\newblock \bibinfo{journal}{Phys. Rev. Lett}
+  \href{http://ascl.net/1401.003}{{\tt ascl:1401.003}}.
+%Type = Article
+\bibitem[{Two(2014)}]{eprint2}
+\bibinfo{author}{Two, B.}, \bibinfo{year}{2014}.
+\newblock \bibinfo{title}{Another article with preprint}.
+\newblock \bibinfo{journal}{Phys. Rev. Lett}
+  \href{http://arxiv.org/abs/1401.0002}{{\tt arXiv:1401.0002}}.
+
+\end{thebibliography}

--- a/tests/test-inproceedings.aux
+++ b/tests/test-inproceedings.aux
@@ -1,6 +1,6 @@
-% This test is associated with https://github.com/rivervalley/elsarticle/issues/1 
-% The content of .bbl-correct in this revision is the output of the
-% model2-names-astronomy.bst file before any fixes.
+% This test checks issue rivervalley/elsarticle#1
+% This appears to have been fixed at some point before this test was
+% created, so that this commit is to record this and close rivervalley/elsarticle#1
 \relax
 \citation{proc1}
 \bibstyle{../model2-names-astronomy}

--- a/tests/test-inproceedings.aux
+++ b/tests/test-inproceedings.aux
@@ -1,0 +1,7 @@
+% This test is associated with https://github.com/rivervalley/elsarticle/issues/1 
+% The content of .bbl-correct in this revision is the output of the
+% model2-names-astronomy.bst file before any fixes.
+\relax
+\citation{proc1}
+\bibstyle{../model2-names-astronomy}
+\bibdata{model2-names-test}

--- a/tests/test-inproceedings.bbl-correct
+++ b/tests/test-inproceedings.bbl-correct
@@ -1,0 +1,24 @@
+\begin{thebibliography}{1}
+\expandafter\ifx\csname natexlab\endcsname\relax\def\natexlab#1{#1}\fi
+\providecommand{\url}[1]{\texttt{#1}}
+\providecommand{\href}[2]{#2}
+\providecommand{\path}[1]{#1}
+\providecommand{\DOIprefix}{doi:}
+\providecommand{\ArXivprefix}{arXiv:}
+\providecommand{\URLprefix}{URL: }
+\providecommand{\Pubmedprefix}{pmid:}
+\providecommand{\doi}[1]{\href{http://dx.doi.org/#1}{\path{#1}}}
+\providecommand{\Pubmed}[1]{\href{pmid:#1}{\path{#1}}}
+\providecommand{\bibinfo}[2]{#2}
+\ifx\xfnm\relax \def\xfnm[#1]{\unskip,\space#1}\fi
+%Type = Inproceedings
+\bibitem[{One and Two(2014)}]{proc1}
+\bibinfo{author}{One, A.}, \bibinfo{author}{Two, B.}, \bibinfo{year}{2014}.
+\newblock \bibinfo{title}{Albie and ben's wonderful adventure}, in:
+  \bibinfo{editor}{Ten, Z.}, \bibinfo{editor}{Nine, Y.} (Eds.),
+  \bibinfo{booktitle}{Proceedings of the Incredibly Interesting Conference},
+  \bibinfo{publisher}{Publishers Megacorp}. number~\bibinfo{number}{99} in
+  \bibinfo{series}{Fascinating and Fun Factbooks}. pp.
+  \bibinfo{pages}{123--124}.
+
+\end{thebibliography}

--- a/tests/test-inproceedings.bbl-correct
+++ b/tests/test-inproceedings.bbl-correct
@@ -4,7 +4,6 @@
 \providecommand{\href}[2]{#2}
 \providecommand{\path}[1]{#1}
 \providecommand{\DOIprefix}{doi:}
-\providecommand{\ArXivprefix}{arXiv:}
 \providecommand{\URLprefix}{URL: }
 \providecommand{\Pubmedprefix}{pmid:}
 \providecommand{\doi}[1]{\href{http://dx.doi.org/#1}{\path{#1}}}

--- a/tests/test-maxauthors.aux
+++ b/tests/test-maxauthors.aux
@@ -1,0 +1,8 @@
+% This tests that the maximum-author processing works as expected.
+\citation{one}
+\citation{oneplus}
+\citation{three}
+\citation{eight}
+\citation{nine}
+\bibstyle{../model2-names-astronomy}
+\bibdata{model2-names-test}

--- a/tests/test-maxauthors.bbl-correct
+++ b/tests/test-maxauthors.bbl-correct
@@ -1,0 +1,50 @@
+\begin{thebibliography}{5}
+\expandafter\ifx\csname natexlab\endcsname\relax\def\natexlab#1{#1}\fi
+\providecommand{\url}[1]{\texttt{#1}}
+\providecommand{\href}[2]{#2}
+\providecommand{\path}[1]{#1}
+\providecommand{\DOIprefix}{doi:}
+\providecommand{\URLprefix}{URL: }
+\providecommand{\Pubmedprefix}{pmid:}
+\providecommand{\doi}[1]{\href{http://dx.doi.org/#1}{\path{#1}}}
+\providecommand{\Pubmed}[1]{\href{pmid:#1}{\path{#1}}}
+\providecommand{\bibinfo}[2]{#2}
+\ifx\xfnm\relax \def\xfnm[#1]{\unskip,\space#1}\fi
+%Type = Article
+\bibitem[{One(2001)}]{one}
+\bibinfo{author}{One, A.}, \bibinfo{year}{2001}.
+\newblock \bibinfo{title}{One alone}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{1},
+  \bibinfo{pages}{101--104}.
+%Type = Article
+\bibitem[{One  et~al.(2001)One et~al.}]{oneplus}
+\bibinfo{author}{One, A.}, et~al., \bibinfo{year}{2001}.
+\newblock \bibinfo{title}{One with friends}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{1},
+  \bibinfo{pages}{111--114}.
+%Type = Article
+\bibitem[{One et~al.(2001a)One, Two and Three}]{three}
+\bibinfo{author}{One, A.}, \bibinfo{author}{Two, B.}, \bibinfo{author}{Three,
+  C.}, \bibinfo{year}{2001}a.
+\newblock \bibinfo{title}{Three alone}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{3},
+  \bibinfo{pages}{301--304}.
+%Type = Article
+\bibitem[{One et~al.(2001b)One, Two, Three, Four, Five, Six, Seven and
+  Eight}]{eight}
+\bibinfo{author}{One, A.}, \bibinfo{author}{Two, B.}, \bibinfo{author}{Three,
+  C.}, \bibinfo{author}{Four, D.}, \bibinfo{author}{Five, E.},
+  \bibinfo{author}{Six, F.}, \bibinfo{author}{Seven, G.},
+  \bibinfo{author}{Eight, H.}, \bibinfo{year}{2001}b.
+\newblock \bibinfo{title}{Eight alone}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{8},
+  \bibinfo{pages}{801--804}.
+%Type = Article
+\bibitem[{One et~al.(2001c)One, Two, Three, Four, Five, Six, Seven, Eight and
+  Nine}]{nine}
+One, A. et~al., \bibinfo{year}{2001}c.
+\newblock \bibinfo{title}{Nine alone}.
+\newblock \bibinfo{journal}{A\&C} \bibinfo{volume}{9},
+  \bibinfo{pages}{901--904}.
+
+\end{thebibliography}


### PR DESCRIPTION
I've suggested four changes here; feel free to cherry-pick.
1. test framework: this just creates a test/ directory, and a Makefile for managing regression tests
2. issue 1: it appears that this was already fixed in the upstream version, so this commit simply closes the issue
3. issue 2: trivial fix
4. implement `eprints` field prefixes.

The last may require thought: the `eprints` field is somewhat overloaded.  It most often (at least in this community) refers to arXiv, but may also refer to ASCL.net (the journal A&C is encouraging this).  It has been proposed (by me and others, and http://adswww.harvard.edu/ already implements this), that this can be resolved by supporting a prefix in the value. Thus `eprints="arxiv:yyyy.nnnn"` or `eprints="ascl:yyyy.nnn"` or the original, plain, `eprints="yyyy.nnnn"`, referring to arXiv by default.  The changes in the last commit implement this.

I (speaking as an A&C editor) will propose this eprints resolution to the journal manager, noting that this has proved implementable in fact.
